### PR TITLE
Patch SWIG-based NumPy interface used by SPAMS (support 1.10.x)

### DIFF
--- a/spams/meta.yaml
+++ b/spams/meta.yaml
@@ -39,7 +39,9 @@ source:
 
   ## Patches may optionally be applied to the source
   patches:
-    - setup.py.patch    # the patch file is expected to be found in the recipe
+    - setup.py.patch                   # the patch file is expected to be found in the recipe
+    - spams_wrap.cpp.patch             # the patch file is expected to be found in the recipe
+    - spams_wrap-windows.cpp.patch     # the patch file is expected to be found in the recipe
 
   #########################################################################
   # Note, the source section is optional. If you want to specify a source #

--- a/spams/meta.yaml
+++ b/spams/meta.yaml
@@ -58,7 +58,7 @@ source:
 
 build:
   # The build number should be incremented for new builds of the same version
-  number: 2        # (defaults to 0)
+  number: 4        # (defaults to 0)
   #string: abc     # (defaults to default conda build string plus the build
   #                # number)
   #                # The build string cannot contain a dash '-' character

--- a/spams/spams_wrap-windows.cpp.patch
+++ b/spams/spams_wrap-windows.cpp.patch
@@ -1,0 +1,17 @@
+diff --git spams_wrap-windows.cpp spams_wrap-windows.cpp
+index 981ac1c..e2af7dd 100644
+--- spams_wrap-windows.cpp
++++ spams_wrap-windows.cpp
+@@ -3157,9 +3157,9 @@ SWIG_From_int  (int value)
+ #define array_dimensions(a)    (((PyArrayObject *)a)->dimensions)
+ #define array_size(a,i)        (((PyArrayObject *)a)->dimensions[i])
+ #define array_data(a)          (((PyArrayObject *)a)->data)
+-#define array_is_contiguous(a) (PyArray_ISCONTIGUOUS(a))
+-#define array_is_native(a)     (PyArray_ISNOTSWAPPED(a))
+-#define array_is_fortran(a)    (PyArray_ISFORTRAN(a))
++#define array_is_contiguous(a) (PyArray_ISCONTIGUOUS((PyArrayObject*)a))
++#define array_is_native(a)     (PyArray_ISNOTSWAPPED((PyArrayObject*)a))
++#define array_is_fortran(a)    (PyArray_IS_F_CONTIGUOUS((PyArrayObject*)a))
+ 
+ 
+   /* Given a PyObject, return a string describing its type.

--- a/spams/spams_wrap.cpp.patch
+++ b/spams/spams_wrap.cpp.patch
@@ -1,0 +1,17 @@
+diff --git spams_wrap.cpp spams_wrap.cpp
+index b08b9e6..b3cb765 100644
+--- spams_wrap.cpp
++++ spams_wrap.cpp
+@@ -3159,9 +3159,9 @@ SWIG_From_int  (int value)
+ #define array_dimensions(a)    (((PyArrayObject *)a)->dimensions)
+ #define array_size(a,i)        (((PyArrayObject *)a)->dimensions[i])
+ #define array_data(a)          (((PyArrayObject *)a)->data)
+-#define array_is_contiguous(a) (PyArray_ISCONTIGUOUS(a))
+-#define array_is_native(a)     (PyArray_ISNOTSWAPPED(a))
+-#define array_is_fortran(a)    (PyArray_ISFORTRAN(a))
++#define array_is_contiguous(a) (PyArray_ISCONTIGUOUS((PyArrayObject*)a))
++#define array_is_native(a)     (PyArray_ISNOTSWAPPED((PyArrayObject*)a))
++#define array_is_fortran(a)    (PyArray_IS_F_CONTIGUOUS((PyArrayObject*)a))
+ 
+ 
+   /* Given a PyObject, return a string describing its type.


### PR DESCRIPTION
Includes patches that improve SPAMS support with NumPy 1.10.x. This has been tested on NumPy 1.10.2rc1.