### PR TITLE
Fix VIGRA build

### DIFF
--- a/vigra/build.sh
+++ b/vigra/build.sh
@@ -15,7 +15,7 @@ VIGRA_LDFLAGS="${CXX_LDFLAGS} -Wl,-rpath,${PREFIX}/lib -L${PREFIX}/lib"
 
 # We like to make builds of vigra from arbitrary git commits (not always tagged).
 # Include the git commit in the build version so we remember which one was used for the build.
-echo "$GIT_DESCRIBE_HASH" > __conda_version__.txt 
+echo "g$(git rev-parse --short HEAD)" > __conda_version__.txt
 
 # CONFIGURE
 mkdir build

--- a/vigra/meta.yaml
+++ b/vigra/meta.yaml
@@ -21,7 +21,7 @@ source:
   # or from git:
   # git_url can also be a relative path to the recipe directory
   git_url: git://github.com/ukoethe/vigra.git
-  git_tag: e4946fe0387bf9086ef074da6912c763f832c053 # must include commit e4946fe0387bf9086ef074da6912c763f832c053
+  git_tag: ca2246798fed70e8a7bd0994f22ee9f857e9aba0 # must include commit e4946fe0387bf9086ef074da6912c763f832c053
 
   ## or from hg:
   #hg_url: ssh://hg@bitbucket.org/ilanschnell/bsdiff4


### PR DESCRIPTION
* Update to support NumPy 1.10.x
* Construct `GIT_DESCRIBE_HASH` as this no longer exists