### PR TITLE
Update NumPy 1.10.x

### DIFF
--- a/numpy/meta.yaml
+++ b/numpy/meta.yaml
@@ -1,10 +1,10 @@
 package:
   name: numpy
-  version: 1.10.1
+  version: 1.10.2rc1
 
 source:
-  url: https://pypi.python.org/packages/source/n/numpy/numpy-1.10.1.tar.gz
-  fn: numpy-1.10.1.tar.gz
+  url: https://github.com/numpy/numpy/archive/v1.10.2rc1.tar.gz
+  fn: numpy-1.10.2rc1.tar.gz
 
 requirements:
   build:

--- a/numpy/meta.yaml
+++ b/numpy/meta.yaml
@@ -1,10 +1,10 @@
 package:
   name: numpy
-  version: 1.10.0
+  version: 1.10.1
 
 source:
-  url: https://pypi.python.org/packages/source/n/numpy/numpy-1.10.0.tar.gz
-  fn: numpy-1.10.0.tar.gz
+  url: https://pypi.python.org/packages/source/n/numpy/numpy-1.10.1.tar.gz
+  fn: numpy-1.10.1.tar.gz
 
 requirements:
   build:

--- a/numpy/meta.yaml
+++ b/numpy/meta.yaml
@@ -1,10 +1,10 @@
 package:
   name: numpy
-  version: 1.10.2rc1
+  version: 1.10.2
 
 source:
-  url: https://github.com/numpy/numpy/archive/v1.10.2rc1.tar.gz
-  fn: numpy-1.10.2rc1.tar.gz
+  url: https://github.com/numpy/numpy/archive/v1.10.2.tar.gz
+  fn: numpy-1.10.2.tar.gz
 
 requirements:
   build:

--- a/numpy/meta.yaml
+++ b/numpy/meta.yaml
@@ -1,10 +1,10 @@
 package:
   name: numpy
-  version: 1.9.3
+  version: 1.10.0
 
 source:
-  url: https://pypi.python.org/packages/source/n/numpy/numpy-1.9.3.tar.gz
-  fn: numpy-1.9.3.tar.gz
+  url: https://pypi.python.org/packages/source/n/numpy/numpy-1.10.0.tar.gz
+  fn: numpy-1.10.0.tar.gz
 
 requirements:
   build:
@@ -16,7 +16,7 @@ requirements:
     - openblas
 
 build:
-  number: 0
+  number: 100
 
   features:
     - openblas

--- a/pyfftw/meta.yaml
+++ b/pyfftw/meta.yaml
@@ -19,7 +19,7 @@ requirements:
         - fftw
 
 build:
-  number: 1
+  number: 2
 
 test:
     # Python imports

--- a/qimage2ndarray/meta.yaml
+++ b/qimage2ndarray/meta.yaml
@@ -10,7 +10,7 @@ source:
    # List any patch files here
    # - fix.patch
 
-# build:
+build:
   # preserve_egg_dir: True
   # entry_points:
     # Put any entry points (scripts to be generated automatically) here. The
@@ -23,7 +23,7 @@ source:
 
   # If this is a new build for the same version, increment the build
   # number. If you do not include this key, it defaults to 0.
-  # number: 1
+  number: 1
 
 requirements:
   build:

--- a/scipy/meta.yaml
+++ b/scipy/meta.yaml
@@ -19,7 +19,7 @@ requirements:
     - numpy
 
 build:
-  number: 102
+  number: 104
 
   features:
     - openblas

--- a/spams/meta.yaml
+++ b/spams/meta.yaml
@@ -58,7 +58,7 @@ source:
 
 build:
   # The build number should be incremented for new builds of the same version
-  number: 4        # (defaults to 0)
+  number: 5        # (defaults to 0)
   #string: abc     # (defaults to default conda build string plus the build
   #                # number)
   #                # The build string cannot contain a dash '-' character

--- a/tifffile/meta.yaml
+++ b/tifffile/meta.yaml
@@ -10,7 +10,7 @@ source:
    # List any patch files here
    # - fix.patch
 
-# build:
+build:
   # preserve_egg_dir: True
   # entry_points:
     # Put any entry points (scripts to be generated automatically) here. The
@@ -23,7 +23,7 @@ source:
 
   # If this is a new build for the same version, increment the build
   # number. If you do not include this key, it defaults to 0.
-  # number: 1
+  number: 1
 
 requirements:
   build:

--- a/vigra/meta.yaml
+++ b/vigra/meta.yaml
@@ -56,7 +56,7 @@ source:
 
 build:
   # The build number should be incremented for new builds of the same version
-  number: 3        # (defaults to 0)
+  number: 4        # (defaults to 0)
   #string: abc     # (defaults to default conda build string plus the build
   #                # number)
   #                # The build string cannot contain a dash '-' character

--- a/volumina/meta.yaml
+++ b/volumina/meta.yaml
@@ -9,7 +9,7 @@ source:
 build:
   # If this is a new build for the same version, increment the build
   # number. If you do not include this key, it defaults to 0.
-  number: 0
+  number: 1
 
   # Whether binary files should be made relocatable using install_name_tool
   # on OS X or patchelf on Linux.


### PR DESCRIPTION
Updates NumPy to 1.10.x and bumps related build numbers so things will go smoothly.