### PR TITLE
Update SciPy to 0.16.1

### DIFF
--- a/scipy/meta.yaml
+++ b/scipy/meta.yaml
@@ -1,10 +1,10 @@
 package:
   name: scipy
-  version: 0.16.0
+  version: 0.16.1
 
 source:
-  url: https://pypi.python.org/packages/source/s/scipy/scipy-0.16.0.tar.gz
-  fn: scipy-0.16.0.tar.gz
+  url: https://pypi.python.org/packages/source/s/scipy/scipy-0.16.1.tar.gz
+  fn: scipy-0.16.1.tar.gz
 
 requirements:
   build:
@@ -19,7 +19,7 @@ requirements:
     - numpy
 
 build:
-  number: 104
+  number: 100
 
   features:
     - openblas

--- a/spams/meta.yaml
+++ b/spams/meta.yaml
@@ -58,7 +58,7 @@ source:
 
 build:
   # The build number should be incremented for new builds of the same version
-  number: 5        # (defaults to 0)
+  number: 7        # (defaults to 0)
   #string: abc     # (defaults to default conda build string plus the build
   #                # number)
   #                # The build string cannot contain a dash '-' character


### PR DESCRIPTION
Include a recent SciPy bug fix. Test on Mac and the Docker image and found to work.