### PR TITLE
OpenBLAS ensure C API

### DIFF
--- a/numpy/meta.yaml
+++ b/numpy/meta.yaml
@@ -16,7 +16,7 @@ requirements:
     - openblas
 
 build:
-  number: 100
+  number: 102
 
   features:
     - openblas

--- a/openblas/build.sh
+++ b/openblas/build.sh
@@ -9,7 +9,7 @@ fi
 # Build LAPACK.
 # Set number of thread to 1; however, this can be changed by
 # setting OPENBLAS_NUM_THREADS before loading the library.
-make DYNAMIC_ARCH=1 BINARY=${ARCH} NO_LAPACK=0 NO_AFFINITY=1 NUM_THREADS=1 -j${CPU_COUNT}
+make DYNAMIC_ARCH=1 BINARY=${ARCH} NO_CBLAS=0 NO_LAPACK=0 NO_AFFINITY=1 NUM_THREADS=1 -j${CPU_COUNT}
 make install PREFIX=$PREFIX
 
 # Make sure the linked gfortran libraries are searched for on the RPATH.

--- a/openblas/meta.yaml
+++ b/openblas/meta.yaml
@@ -7,7 +7,7 @@ source:
   url: http://github.com/xianyi/OpenBLAS/tarball/v0.2.14
 
 build:
-  number: 674
+  number: 676
 
   track_features:
     - openblas

--- a/scipy/meta.yaml
+++ b/scipy/meta.yaml
@@ -19,7 +19,7 @@ requirements:
     - numpy
 
 build:
-  number: 100
+  number: 102
 
   features:
     - openblas

--- a/spams/meta.yaml
+++ b/spams/meta.yaml
@@ -58,7 +58,7 @@ source:
 
 build:
   # The build number should be incremented for new builds of the same version
-  number: 7        # (defaults to 0)
+  number: 9        # (defaults to 0)
   #string: abc     # (defaults to default conda build string plus the build
   #                # number)
   #                # The build string cannot contain a dash '-' character


### PR DESCRIPTION
Seems the C API may not have been enabled when building OpenBLAS. This stops us from using some of its nicer features through NumPy and SciPy. This tries to remedy this issue.