### PR TITLE
WIP: Fixes for building VIGRA 1.11.0 development release.

### DIFF
--- a/vigra/build.sh
+++ b/vigra/build.sh
@@ -5,7 +5,7 @@ source $CWD/../common-vars.sh
 if [[ `uname` == 'Darwin' ]]; then
     VIGRA_CXX_FLAGS="${CXXFLAGS}"
 else
-    VIGRA_CXX_FLAGS="-pthread ${CXXFLAGS}"
+    VIGRA_CXX_FLAGS="-pthread -std=c++11 ${CXXFLAGS}"
 fi
 
 # In release mode, we use -O2 because gcc is known to miscompile certain vigra functionality at the O3 level.
@@ -31,6 +31,7 @@ cmake ..\
         -DCMAKE_CXX_FLAGS_DEBUG="${VIGRA_CXX_FLAGS}" \
 \
         -DWITH_VIGRANUMPY=TRUE \
+        -DWITH_BOOST_THREAD=1 \
         -DDEPENDENCY_SEARCH_PREFIX=${PREFIX} \
 \
         -DFFTW3F_INCLUDE_DIR=${PREFIX}/include \

--- a/vigra/build.sh
+++ b/vigra/build.sh
@@ -3,7 +3,7 @@ CWD=$(cd `dirname $0` && pwd)
 source $CWD/../common-vars.sh
 
 if [[ `uname` == 'Darwin' ]]; then
-    VIGRA_CXX_FLAGS="${CXXFLAGS}"
+    VIGRA_CXX_FLAGS="-std=c++11 ${CXXFLAGS}"
 else
     VIGRA_CXX_FLAGS="-pthread -std=c++11 ${CXXFLAGS}"
 fi

--- a/vigra/build.sh
+++ b/vigra/build.sh
@@ -15,7 +15,7 @@ VIGRA_LDFLAGS="${CXX_LDFLAGS} -Wl,-rpath,${PREFIX}/lib -L${PREFIX}/lib"
 
 # We like to make builds of vigra from arbitrary git commits (not always tagged).
 # Include the git commit in the build version so we remember which one was used for the build.
-echo "g$(git rev-parse --short HEAD)" > __conda_version__.txt
+#echo "g$(git rev-parse --short HEAD)" > __conda_version__.txt
 
 # CONFIGURE
 mkdir build
@@ -31,7 +31,6 @@ cmake ..\
         -DCMAKE_CXX_FLAGS_DEBUG="${VIGRA_CXX_FLAGS}" \
 \
         -DWITH_VIGRANUMPY=TRUE \
-        -DWITH_BOOST_THREAD=1 \
         -DDEPENDENCY_SEARCH_PREFIX=${PREFIX} \
 \
         -DFFTW3F_INCLUDE_DIR=${PREFIX}/include \
@@ -45,18 +44,9 @@ cmake ..\
 \
         -DBoost_INCLUDE_DIR=${PREFIX}/include \
         -DBoost_LIBRARY_DIRS=${PREFIX}/lib \
-        -DBoost_PYTHON_LIBRARY=${PREFIX}/lib/libboost_python-mt.${DYLIB_EXT} \
-        -DBoost_PYTHON_LIBRARY_RELEASE=${PREFIX}/lib/libboost_python-mt.${DYLIB_EXT} \
-        -DBoost_PYTHON_LIBRARY_DEBUG=${PREFIX}/lib/libboost_python-mt.${DYLIB_EXT} \
 \
         -DPYTHON_EXECUTABLE=${PYTHON} \
         -DPYTHON_INCLUDE_PATH=${PREFIX}/include \
-        -DPYTHON_LIBRARIES=${PREFIX}/lib/libpython.2.7.${DYLIB_EXT} \
-        -DPYTHON_NUMPY_INCLUDE_DIR=${PREFIX}/lib/python2.7/site-packages/numpy/core/include \
-        -DPYTHON_SPHINX=${PREFIX}/bin/sphinx-build \
-\
-        -DVIGRANUMPY_LIBRARIES="${PREFIX}/lib/libpython2.7.${DYLIB_EXT};${PREFIX}/lib/libboost_python.${DYLIB_EXT};${PREFIX}/lib/libboost_thread.${DYLIB_EXT};${PREFIX}/lib/libboost_system.${DYLIB_EXT}" \
-        -DVIGRANUMPY_INSTALL_DIR=${PREFIX}/lib/python2.7/site-packages \
 \
         -DZLIB_INCLUDE_DIR=${PREFIX}/include \
         -DZLIB_LIBRARY=${PREFIX}/lib/libz.${DYLIB_EXT} \

--- a/vigra/meta.yaml
+++ b/vigra/meta.yaml
@@ -1,13 +1,13 @@
 package:
-  name: vigra         # lower case name of package, may contain '-' but no spaces
-  version: "1.10"     # version of package. Should use the PEP-386 verlib
-                      # conventions. Note that YAML will interpret
-                      # versions like 1.0 as floats, meaning that 1.0 will
-                      # be the same as 1. To avoid this, always put the
-                      # version in quotes, so that it will be interpreted
-                      # as a string.
+  name: vigra              # lower case name of package, may contain '-' but no spaces
+  version: "1.11.0dev0"    # version of package. Should use the PEP-386 verlib
+                           # conventions. Note that YAML will interpret
+                           # versions like 1.0 as floats, meaning that 1.0 will
+                           # be the same as 1. To avoid this, always put the
+                           # version in quotes, so that it will be interpreted
+                           # as a string.
 
-                      # The version cannot contain a dash '-' character.
+                           # The version cannot contain a dash '-' character.
 
 source:
   ## The source section specifies where the source code of the package is
@@ -21,7 +21,7 @@ source:
   # or from git:
   # git_url can also be a relative path to the recipe directory
   git_url: git://github.com/ukoethe/vigra.git
-  git_tag: ca2246798fed70e8a7bd0994f22ee9f857e9aba0 # must include commit e4946fe0387bf9086ef074da6912c763f832c053
+  git_tag: 777f70b872751a3459aa405e294dd60c5227b2d9 # must include commit e4946fe0387bf9086ef074da6912c763f832c053
 
   ## or from hg:
   #hg_url: ssh://hg@bitbucket.org/ilanschnell/bsdiff4
@@ -56,7 +56,7 @@ source:
 
 build:
   # The build number should be incremented for new builds of the same version
-  number: 4        # (defaults to 0)
+  number: 0        # (defaults to 0)
   #string: abc     # (defaults to default conda build string plus the build
   #                # number)
   #                # The build string cannot contain a dash '-' character

--- a/vigra/meta.yaml
+++ b/vigra/meta.yaml
@@ -56,7 +56,7 @@ source:
 
 build:
   # The build number should be incremented for new builds of the same version
-  number: 0        # (defaults to 0)
+  number: 1        # (defaults to 0)
   #string: abc     # (defaults to default conda build string plus the build
   #                # number)
   #                # The build string cannot contain a dash '-' character


### PR DESCRIPTION
This is far from final. Appears that I can't have Boost.Thread on Mac, but I must on Linux. At least that is how it appears at present. Will need to figure out why this is and see if I can't eliminate Boost.Thread from both platforms.
