### PR TITLE
Build packages so MKL is not required

### DIFF
--- a/numpy/meta.yaml
+++ b/numpy/meta.yaml
@@ -19,9 +19,10 @@ requirements:
     - openblas
 
 build:
-  number: 102
+  number: 104
 
   features:
+    - nomkl
     - openblas
 
 about:

--- a/openblas/meta.yaml
+++ b/openblas/meta.yaml
@@ -7,13 +7,20 @@ source:
   url: http://github.com/xianyi/OpenBLAS/tarball/v0.2.15
 
 build:
-  number: 100
+  number: 102
+
+  features:
+    - nomkl
 
   track_features:
     - openblas
 
 requirements:
+  build:
+    - nomkl
+
   run:
+    - nomkl
     - libgcc
 
 about:

--- a/scipy/meta.yaml
+++ b/scipy/meta.yaml
@@ -20,9 +20,10 @@ requirements:
     - numpy
 
 build:
-  number: 102
+  number: 104
 
   features:
+    - nomkl
     - openblas
 
 about:

--- a/spams/meta.yaml
+++ b/spams/meta.yaml
@@ -165,8 +165,8 @@ test:
   # in addition to the run-time requirements, you can specify requirements
   # needed during testing. The run time requirements specified above are
   # included automatically.
-  requires:
-    - openblas
+  #requires:
+  #  - openblas
 
   ## commands we want to make sure they work, which are expected to get
   ## installed by the package

--- a/spams/meta.yaml
+++ b/spams/meta.yaml
@@ -58,7 +58,7 @@ source:
 
 build:
   # The build number should be incremented for new builds of the same version
-  number: 9        # (defaults to 0)
+  number: 11       # (defaults to 0)
   #string: abc     # (defaults to default conda build string plus the build
   #                # number)
   #                # The build string cannot contain a dash '-' character
@@ -78,6 +78,7 @@ build:
 
   ## Defines what features a package has
   features:
+    - nomkl
     - openblas
 
   ## Indicates that installing this package should enable (track) the given

--- a/vigra/build.sh
+++ b/vigra/build.sh
@@ -72,11 +72,11 @@ cmake ..\
 
 
 # BUILD (in parallel)
-make -j${CPU_COUNT}
+make -j2
 
 # TEST (before install)
 # (Since conda hasn't performed its link step yet, we must help the tests locate their dependencies via LD_LIBRARY_PATH)
-eval ${LIBRARY_SEARCH_VAR}=$PREFIX/lib make -j${CPU_COUNT} check
+eval ${LIBRARY_SEARCH_VAR}=$PREFIX/lib make -j2 check
 
 # "install" to the build prefix (conda will relocate these files afterwards)
 make install


### PR DESCRIPTION
Fixes https://github.com/nanshe-org/nanshe-build/issues/27

Tracks the `nomkl` feature in all relevant packages to make sure they are built using OpenBLAS and not MKL.