### PR TITLE
Require Cython for building NumPy and SciPy

### DIFF
--- a/numpy/meta.yaml
+++ b/numpy/meta.yaml
@@ -11,6 +11,7 @@ source:
 requirements:
   build:
     - python
+    - cython
     - openblas 
 
   run:

--- a/scipy/meta.yaml
+++ b/scipy/meta.yaml
@@ -9,6 +9,7 @@ source:
 requirements:
   build:
     - python
+    - cython
     - openblas
     - numpy
 


### PR DESCRIPTION
Fixes https://github.com/nanshe-org/nanshe-build/issues/29

Seems to be the only sensible solution as the C source code may not be generated in the version we use. This way we can generate it ourselves.