### PR TITLE
Fix scikit-learn SVD sign flip bug

### DIFF
--- a/scikit-learn/meta.yaml
+++ b/scikit-learn/meta.yaml
@@ -5,6 +5,8 @@ package:
 source:
   url: https://pypi.python.org/packages/source/s/scikit-learn/scikit-learn-0.17.tar.gz
   fn: scikit-learn-0.17.tar.gz
+  patches:
+    - svd_sign_flip.patch
 
 requirements:
   build:

--- a/scikit-learn/meta.yaml
+++ b/scikit-learn/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: scikit-learn
-  version: 0.17
+  version: 0.17.0.1
 
 source:
   url: https://pypi.python.org/packages/source/s/scikit-learn/scikit-learn-0.17.tar.gz
@@ -24,7 +24,7 @@ requirements:
     - scipy
 
 build:
-  number: 102
+  number: 100
 
   features:
     - nomkl

--- a/scikit-learn/svd_sign_flip.patch
+++ b/scikit-learn/svd_sign_flip.patch
@@ -1,0 +1,68 @@
+diff --git a/sklearn/utils/extmath.py b/sklearn/utils/extmath.py
+index a1a3bf4..33c174a 100644
+--- a/sklearn/utils/extmath.py
++++ b/sklearn/utils/extmath.py
+@@ -305,7 +305,12 @@ def randomized_svd(M, n_components, n_oversamples=10, n_iter=0,
+     U = np.dot(Q, Uhat)
+ 
+     if flip_sign:
+-        U, V = svd_flip(U, V)
++        if not transpose:
++            U, V = svd_flip(U, V)
++        else:
++            # In case of transpose u_based_decision=false
++            # to actually flip based on u and not v.
++            U, V = svd_flip(U, V, u_based_decision=False)
+ 
+     if transpose:
+         # transpose back the results according to the input convention
+diff --git a/sklearn/utils/tests/test_extmath.py b/sklearn/utils/tests/test_extmath.py
+index 0df11da..bd19cca 100644
+--- a/sklearn/utils/tests/test_extmath.py
++++ b/sklearn/utils/tests/test_extmath.py
+@@ -14,6 +14,7 @@ from sklearn.utils.testing import assert_almost_equal
+ from sklearn.utils.testing import assert_array_equal
+ from sklearn.utils.testing import assert_array_almost_equal
+ from sklearn.utils.testing import assert_true
++from sklearn.utils.testing import assert_false
+ from sklearn.utils.testing import assert_greater
+ from sklearn.utils.testing import assert_raises
+ from sklearn.utils.testing import skip_if_32bit
+@@ -287,6 +288,37 @@ def test_randomized_svd_sign_flip():
+         assert_almost_equal(np.dot(v2.T, v2), np.eye(2))
+ 
+ 
++def test_randomized_svd_sign_flip_with_transpose():
++    # Check if the randomized_svd sign flipping is always done based on u
++    # irrespective of transpose.
++    # See https://github.com/scikit-learn/scikit-learn/issues/5608
++    # for more details.
++    def max_loading_is_positive(u, v):
++        """
++        returns bool tuple indicating if the values maximising np.abs
++        are positive across all rows for u and across all columns for v.
++        """
++        u_based = (np.abs(u).max(axis=0) == u.max(axis=0)).all()
++        v_based = (np.abs(v).max(axis=1) == v.max(axis=1)).all()
++        return u_based, v_based
++
++    mat = np.arange(10 * 8).reshape(10, -1)
++
++    # Without transpose
++    u_flipped, _, v_flipped = randomized_svd(mat, 3, flip_sign=True)
++    u_based, v_based = max_loading_is_positive(u_flipped, v_flipped)
++    assert_true(u_based)
++    assert_false(v_based)
++
++    # With transpose
++    u_flipped_with_transpose, _, v_flipped_with_transpose = randomized_svd(
++        mat, 3, flip_sign=True, transpose=True)
++    u_based, v_based = max_loading_is_positive(
++        u_flipped_with_transpose, v_flipped_with_transpose)
++    assert_true(u_based)
++    assert_false(v_based)
++
++
+ def test_cartesian():
+     # Check if cartesian product delivers the right results
+

--- a/scikit-learn/svd_sign_flip.patch
+++ b/scikit-learn/svd_sign_flip.patch
@@ -1,7 +1,7 @@
-diff --git a/sklearn/utils/extmath.py b/sklearn/utils/extmath.py
+diff --git sklearn/utils/extmath.py sklearn/utils/extmath.py
 index a1a3bf4..33c174a 100644
---- a/sklearn/utils/extmath.py
-+++ b/sklearn/utils/extmath.py
+--- sklearn/utils/extmath.py
++++ sklearn/utils/extmath.py
 @@ -305,7 +305,12 @@ def randomized_svd(M, n_components, n_oversamples=10, n_iter=0,
      U = np.dot(Q, Uhat)
  
@@ -16,10 +16,10 @@ index a1a3bf4..33c174a 100644
  
      if transpose:
          # transpose back the results according to the input convention
-diff --git a/sklearn/utils/tests/test_extmath.py b/sklearn/utils/tests/test_extmath.py
+diff --git sklearn/utils/tests/test_extmath.py sklearn/utils/tests/test_extmath.py
 index 0df11da..bd19cca 100644
---- a/sklearn/utils/tests/test_extmath.py
-+++ b/sklearn/utils/tests/test_extmath.py
+--- sklearn/utils/tests/test_extmath.py
++++ sklearn/utils/tests/test_extmath.py
 @@ -14,6 +14,7 @@ from sklearn.utils.testing import assert_almost_equal
  from sklearn.utils.testing import assert_array_equal
  from sklearn.utils.testing import assert_array_almost_equal


### PR DESCRIPTION
Applies this patch ( https://github.com/scikit-learn/scikit-learn/pull/6375 ) to scikit-learn 0.17.0. To create 0.17.0.1, which appears to work correctly. 