### PR TITLE
Use nomkl

### DIFF
--- a/numpy/meta.yaml
+++ b/numpy/meta.yaml
@@ -12,6 +12,7 @@ requirements:
   build:
     - python
     - cython
+    - nomkl
     - openblas 
 
   run:
@@ -19,7 +20,7 @@ requirements:
     - openblas
 
 build:
-  number: 104
+  number: 106
 
   features:
     - nomkl

--- a/scikit-learn/meta.yaml
+++ b/scikit-learn/meta.yaml
@@ -10,6 +10,7 @@ requirements:
   build:
     - python
     - cython
+    - nomkl
     - openblas
     - numpy
     - scipy
@@ -22,7 +23,7 @@ requirements:
     - scipy
 
 build:
-  number: 100
+  number: 102
 
   features:
     - nomkl

--- a/scipy/meta.yaml
+++ b/scipy/meta.yaml
@@ -10,6 +10,7 @@ requirements:
   build:
     - python
     - cython
+    - nomkl
     - openblas
     - numpy
 
@@ -20,7 +21,7 @@ requirements:
     - numpy
 
 build:
-  number: 100
+  number: 102
 
   features:
     - nomkl

--- a/spams/meta.yaml
+++ b/spams/meta.yaml
@@ -58,7 +58,7 @@ source:
 
 build:
   # The build number should be incremented for new builds of the same version
-  number: 13       # (defaults to 0)
+  number: 15       # (defaults to 0)
   #string: abc     # (defaults to default conda build string plus the build
   #                # number)
   #                # The build string cannot contain a dash '-' character
@@ -144,6 +144,7 @@ requirements:
   build:
     - gcc
     - python
+    - nomkl
     - openblas
     - numpy
     - scipy


### PR DESCRIPTION
Require `nomkl` as a build time dependency of all packages built with OpenBLAS.